### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-scalamatsuri.org
+2020.scalamatsuri.org


### PR DESCRIPTION
2020.scalamatsuri.orgが、ここを指すようにする